### PR TITLE
Hooking GetUserName* GetComputerName* APIs. Closes #28. Must be verified...

### DIFF
--- a/cuckoomon.c
+++ b/cuckoomon.c
@@ -251,6 +251,10 @@ static hook_t g_hooks[] = {
     HOOK(kernel32, WriteConsoleW),
     HOOK(user32, GetSystemMetrics),
     HOOK(user32, GetCursorPos),
+    HOOK(kernel32, GetComputerNameA),
+    HOOK(kernel32, GetComputerNameW),
+    HOOK(advapi32, GetUserNameA),
+    HOOK(advapi32, GetUserNameW),
 
     //
     // Network Hooks

--- a/hook_misc.c
+++ b/hook_misc.c
@@ -260,3 +260,51 @@ HOOKDEF(BOOL, WINAPI, GetCursorPos,
         "y", lpPoint != NULL ? lpPoint->y : 0);
     return ret;
 }
+
+HOOKDEF(BOOL, WINAPI, GetComputerNameA,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+) {
+    IS_SUCCESS_BOOL();
+
+    static const char *category = "misc";
+    BOOL ret = Old_GetComputerNameA(lpBuffer, lpnSize);
+    LOQ("s", "ComputerName", lpBuffer);
+    return ret;
+}
+
+HOOKDEF(BOOL, WINAPI, GetComputerNameW,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+) {
+    IS_SUCCESS_BOOL();
+
+    static const char *category = "misc";
+    BOOL ret = Old_GetComputerNameW(lpBuffer, lpnSize);
+    LOQ("u", "ComputerName", lpBuffer);
+    return ret;
+}
+
+HOOKDEF(BOOL, WINAPI, GetUserNameA,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+) {
+    IS_SUCCESS_BOOL();
+
+    static const char *category = "misc";
+    BOOL ret = Old_GetUserNameA(lpBuffer, lpnSize);
+    LOQ("s", "Name", lpBuffer);
+    return ret;
+}
+
+HOOKDEF(BOOL, WINAPI, GetUserNameW,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+) {
+    IS_SUCCESS_BOOL();
+    
+    static const char *category = "misc";
+    BOOL ret = Old_GetUserNameW(lpBuffer, lpnSize);
+    LOQ("u", "Name", lpBuffer);
+    return ret;
+}

--- a/hooks.h
+++ b/hooks.h
@@ -1001,6 +1001,26 @@ extern HOOKDEF(BOOL, WINAPI, GetCursorPos,
     _Out_ LPPOINT lpPoint
 );
 
+extern HOOKDEF(BOOL, WINAPI, GetComputerNameA,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+);
+
+extern HOOKDEF(BOOL, WINAPI, GetComputerNameW,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+);
+
+extern HOOKDEF(BOOL, WINAPI, GetUserNameA,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+);
+
+extern HOOKDEF(BOOL, WINAPI, GetUserNameW,
+    _Out_    LPTSTR lpBuffer,
+    _Inout_  LPDWORD lpnSize
+);
+
 //
 // Network Hooks
 //


### PR DESCRIPTION
..., has inconsistent arg count. At the moment I am not sure if the bug is in my code or in the logging function.
